### PR TITLE
refactor(#46) close/canclose/isclosed into node metadata (current state)

### DIFF
--- a/src/__tests__/deterministic-fsm/deterministic-finite-state-machine.spec.ts
+++ b/src/__tests__/deterministic-fsm/deterministic-finite-state-machine.spec.ts
@@ -1,42 +1,47 @@
-import { DeterministicStateMachine } from '../../lib';
-import { DeterministicTransitions } from '../../lib/deterministic-fsm/deterministic-transition-map';
+import { createDeterministicMachine } from '../../lib';
 
 describe('deterministic-state-machine with deterministic-transition-fn', () => {
-  const initialState = 'A';
-  const finalStates = new Set(['A', 'B']);
-  const transitions: DeterministicTransitions = new Map([
-    [
-      'A',
-      new Map([
-        ['1', 'B'],
-        ['0', 'A'],
-      ]),
+  const machine = createDeterministicMachine({
+    initialNode: 'A',
+    nodes: [
+      {
+        id: 'A',
+        transitions: new Map([
+          ['1', 'B'],
+          ['0', 'A'],
+        ]),
+        final: true,
+      },
+      {
+        id: 'B',
+        transitions: new Map([
+          ['1', 'A'],
+          ['0', 'B'],
+        ]),
+        final: true,
+      },
     ],
-    [
-      'B',
-      new Map([
-        ['1', 'A'],
-        ['0', 'B'],
-      ]),
-    ],
-  ]);
-  const machine = new DeterministicStateMachine(initialState, finalStates, transitions);
+  });
 
   it('should move A->B->A', () => {
-    machine.handle('1');
-    expect(machine.getCurrentState().currentNode).toBe('B');
-    machine.handle('1');
-    expect(machine.getCurrentState().currentNode).toBe('A');
+    machine.dispatch('1');
+    expect(machine.currentState.currentNode.id).toBe('B');
+    expect(machine.currentState.output).toBeUndefined();
+    machine.dispatch('1');
+    expect(machine.currentState.currentNode.id).toBe('A');
+    expect(machine.currentState.output).toBeUndefined();
   });
 
   it('should move A->A', () => {
-    machine.handle('0');
-    expect(machine.getCurrentState().currentNode).toBe('A');
+    machine.dispatch('0');
+    expect(machine.currentState.currentNode.id).toBe('A');
+    expect(machine.currentState.output).toBeUndefined();
   });
 
   it('should move B->B', () => {
-    machine.handle('1');
-    machine.handle('0');
-    expect(machine.getCurrentState().currentNode).toBe('B');
+    machine.dispatch('1');
+    machine.dispatch('0');
+    expect(machine.currentState.currentNode.id).toBe('B');
+    expect(machine.currentState.output).toBeUndefined();
   });
 });

--- a/src/__tests__/deterministic-fsm/deterministic-transition.test.ts
+++ b/src/__tests__/deterministic-fsm/deterministic-transition.test.ts
@@ -3,21 +3,21 @@ import { createDeterministicTransitions } from '../../lib/deterministic-fsm/dete
 describe('deterministic-transitionFn', () => {
   it('should transition from A->B', () => {
     const transitionFn = createDeterministicTransitions(new Map([['A', new Map([['1', 'B']])]]));
-    expect(transitionFn({ currentNode: 'A' }, '1')).toBe('B');
+    expect(transitionFn({ currentNode: { id: 'A' } }, '1')).toBe('B');
   });
 
   it('should not transition on non existing event', () => {
     const transitionFn = createDeterministicTransitions(new Map([['A', new Map([['1', 'B']])]]));
-    expect(transitionFn({ currentNode: 'A' }, '2')).toBe('A');
+    expect(transitionFn({ currentNode: { id: 'A' } }, '2')).toBeUndefined();
   });
 
   it('should not transition on non existing node', () => {
     const transitionFn = createDeterministicTransitions(new Map([['A', new Map([['1', 'B']])]]));
-    expect(transitionFn({ currentNode: 'C' }, '1')).toBe('C');
+    expect(transitionFn({ currentNode: { id: 'C' } }, '1')).toBeUndefined();
   });
 
   it('should not transition on non existing node', () => {
     const transitionFn = createDeterministicTransitions(new Map([['A', new Map([['1', 'B']])]]));
-    expect(transitionFn({ currentNode: 'C' }, '1')).toBe('C');
+    expect(transitionFn({ currentNode: { id: 'C' } }, '1')).toBeUndefined();
   });
 });

--- a/src/__tests__/mealy-fsm/mealy-finite-state-machine.spec.ts
+++ b/src/__tests__/mealy-fsm/mealy-finite-state-machine.spec.ts
@@ -1,46 +1,47 @@
-import { MealyStateMachine } from '../../lib';
-import { MealyTransitionMap, MealyTransition } from '../../lib/mealy-fsm/mealy-transition-map';
+import { createMealyStateMachine } from '../../lib';
 
 describe('mealy-state-machine with mealy-transition-fn', () => {
-  const initialState = 'A';
-  const finalStates = new Set(['A', 'B']);
-  const transitions: MealyTransitionMap<string> = new Map([
-    [
-      'A',
-      new Map([
-        ['1', new MealyTransition<string>('B', 'output1')],
-        ['0', new MealyTransition<string>('A', 'output2')],
-      ]),
+  const machine = createMealyStateMachine({
+    initialNode: 'A',
+    nodes: [
+      {
+        id: 'A',
+        transitions: new Map([
+          ['1', { node: 'B', output: 'output1' }],
+          ['0', { node: 'A', output: 'output2' }],
+        ]),
+        final: true,
+      },
+      {
+        id: 'B',
+        transitions: new Map([
+          ['1', { node: 'A', output: 'output3' }],
+          ['0', { node: 'B', output: 'output4' }],
+        ]),
+        final: true,
+      },
     ],
-    [
-      'B',
-      new Map([
-        ['1', new MealyTransition<string>('A', 'output3')],
-        ['0', new MealyTransition<string>('B', 'output4')],
-      ]),
-    ],
-  ]);
-  const machine = new MealyStateMachine(initialState, finalStates, transitions);
+  });
 
   it('should move A->B->A', () => {
-    machine.handle('1');
-    expect(machine.getCurrentState().currentNode).toBe('B');
-    expect(machine.getCurrentState().output).toBe('output1');
-    machine.handle('1');
-    expect(machine.getCurrentState().currentNode).toBe('A');
-    expect(machine.getCurrentState().output).toBe('output3');
+    machine.dispatch('1');
+    expect(machine.currentState.currentNode.id).toBe('B');
+    expect(machine.currentState.output).toBe('output1');
+    machine.dispatch('1');
+    expect(machine.currentState.currentNode.id).toBe('A');
+    expect(machine.currentState.output).toBe('output3');
   });
 
   it('should move A->A', () => {
-    machine.handle('0');
-    expect(machine.getCurrentState().currentNode).toBe('A');
-    expect(machine.getCurrentState().output).toBe('output2');
+    machine.dispatch('0');
+    expect(machine.currentState.currentNode.id).toBe('A');
+    expect(machine.currentState.output).toBe('output2');
   });
 
   it('should move B->B', () => {
-    machine.handle('1');
-    machine.handle('0');
-    expect(machine.getCurrentState().currentNode).toBe('B');
-    expect(machine.getCurrentState().output).toBe('output4');
+    machine.dispatch('1');
+    machine.dispatch('0');
+    expect(machine.currentState.currentNode.id).toBe('B');
+    expect(machine.currentState.output).toBe('output4');
   });
 });

--- a/src/__tests__/mealy-fsm/mealy-output.test.ts
+++ b/src/__tests__/mealy-fsm/mealy-output.test.ts
@@ -1,19 +1,18 @@
 import { createMealyOutput } from '../../lib/mealy-fsm/mealy-output.fn';
-import { MealyTransition } from '../../lib/mealy-fsm/mealy-transition-map';
 
 describe('Mealy-output', () => {
   it('should transition from A->B', () => {
-    const outputFn = createMealyOutput(new Map([['A', new Map([['1', new MealyTransition<string>('B', 'output')]])]]));
-    expect(outputFn({ currentNode: 'A' }, '1', 'B')).toBe('output');
+    const outputFn = createMealyOutput(new Map([['A', new Map([['1', 'output']])]]));
+    expect(outputFn({ currentNode: { id: 'A' } }, '1', { id: 'B' })).toBe('output');
   });
 
   it('should not transition on non existing event', () => {
-    const outputFn = createMealyOutput(new Map([['A', new Map([['1', new MealyTransition<string>('B', 'output')]])]]));
-    expect(outputFn({ currentNode: 'A' }, 'X', 'B')).toEqual(Object.create(null));
+    const outputFn = createMealyOutput(new Map([['A', new Map([['1', 'output']])]]));
+    expect(outputFn({ currentNode: { id: 'A' } }, 'X', { id: 'B' })).toBeUndefined();
   });
 
   it('should not transition on non existing node', () => {
-    const outputFn = createMealyOutput(new Map([['A', new Map([['1', new MealyTransition<string>('B', 'output')]])]]));
-    expect(outputFn({ currentNode: 'X' }, '1', 'B')).toEqual(Object.create(null));
+    const outputFn = createMealyOutput(new Map([['A', new Map([['1', 'output']])]]));
+    expect(outputFn({ currentNode: { id: 'x' } }, '1', { id: 'B' })).toBeUndefined();
   });
 });

--- a/src/__tests__/mealy-fsm/mealy-transition.test.ts
+++ b/src/__tests__/mealy-fsm/mealy-transition.test.ts
@@ -1,32 +1,23 @@
 import { createMealyTransitions } from '../../lib/mealy-fsm/mealy-transition.fn';
-import { MealyTransition } from '../../lib/mealy-fsm/mealy-transition-map';
 
 describe('deterministic-transitionFn', () => {
   it('should transition from A->B', () => {
-    const transitionFn = createMealyTransitions(
-      new Map([['A', new Map([['1', new MealyTransition<string>('B', 'output')]])]]),
-    );
-    expect(transitionFn({ currentNode: 'A' }, '1')).toBe('B');
+    const transitionFn = createMealyTransitions(new Map([['A', new Map([['1', 'B']])]]));
+    expect(transitionFn({ currentNode: { id: 'A' } }, '1')).toBe('B');
   });
 
   it('should not transition on non existing event', () => {
-    const transitionFn = createMealyTransitions(
-      new Map([['A', new Map([['1', new MealyTransition<string>('B', 'output')]])]]),
-    );
-    expect(transitionFn({ currentNode: 'A' }, '2')).toBe('A');
+    const transitionFn = createMealyTransitions(new Map([['A', new Map([['1', 'B']])]]));
+    expect(transitionFn({ currentNode: { id: 'A' } }, '2')).toBeUndefined();
   });
 
   it('should not transition on non existing node', () => {
-    const transitionFn = createMealyTransitions(
-      new Map([['A', new Map([['1', new MealyTransition<string>('B', 'output')]])]]),
-    );
-    expect(transitionFn({ currentNode: 'C' }, '1')).toBe('C');
+    const transitionFn = createMealyTransitions(new Map([['A', new Map([['1', 'B']])]]));
+    expect(transitionFn({ currentNode: { id: 'C' } }, '1')).toBeUndefined();
   });
 
   it('should not transition on non existing node', () => {
-    const transitionFn = createMealyTransitions(
-      new Map([['A', new Map([['1', new MealyTransition<string>('B', 'output')]])]]),
-    );
-    expect(transitionFn({ currentNode: 'C' }, '1')).toBe('C');
+    const transitionFn = createMealyTransitions(new Map([['A', new Map([['1', 'B']])]]));
+    expect(transitionFn({ currentNode: { id: 'C' } }, '1')).toBeUndefined();
   });
 });

--- a/src/__tests__/moore-fsm/moore-finite-state-machine.spec.ts
+++ b/src/__tests__/moore-fsm/moore-finite-state-machine.spec.ts
@@ -3,7 +3,7 @@ import { createMooreStateMachine, MooreNode } from '../../lib/moore-fsm';
 describe('moore-state-machine', () => {
   const nodes: MooreNode<string>[] = [
     {
-      name: 'A',
+      id: 'A',
       transitions: new Map([
         ['1', 'B'],
         ['0', 'A'],
@@ -12,7 +12,7 @@ describe('moore-state-machine', () => {
       final: true,
     },
     {
-      name: 'B',
+      id: 'B',
       transitions: new Map([
         ['0', 'B'],
         ['1', 'A'],
@@ -24,55 +24,45 @@ describe('moore-state-machine', () => {
 
   it('should move A->B->A', () => {
     const machine = createMooreStateMachine({
-      initialState: 'A',
+      initialNode: 'A',
       nodes,
     });
 
-    machine.handle('1');
-    expect(machine.getCurrentState().currentNode).toBe('B');
-    expect(machine.getCurrentState().output).toBe('OutputB');
-    machine.handle('1');
-    expect(machine.getCurrentState().currentNode).toBe('A');
-    expect(machine.getCurrentState().output).toBe('OutputA');
+    machine.dispatch('1');
+    expect(machine.currentState.currentNode.id).toBe('B');
+    expect(machine.currentState.output).toBe('OutputB');
+    machine.dispatch('1');
+    expect(machine.currentState.currentNode.id).toBe('A');
+    expect(machine.currentState.output).toBe('OutputA');
   });
 
   it('should move A->A', () => {
     const machine = createMooreStateMachine({
-      initialState: 'A',
+      initialNode: 'A',
       nodes,
     });
-    machine.handle('0');
-    expect(machine.getCurrentState().currentNode).toBe('A');
-    expect(machine.getCurrentState().output).toBe('OutputA');
+    machine.dispatch('0');
+    expect(machine.currentState.currentNode.id).toBe('A');
+    expect(machine.currentState.output).toBe('OutputA');
   });
 
   it('should move B->B', () => {
     const machine = createMooreStateMachine({
-      initialState: 'B',
+      initialNode: 'B',
       nodes,
     });
-    machine.handle('0');
-    expect(machine.getCurrentState().currentNode).toBe('B');
-    expect(machine.getCurrentState().output).toBe('OutputB');
+    machine.dispatch('0');
+    expect(machine.currentState.currentNode.id).toBe('B');
+    expect(machine.currentState.output).toBe('OutputB');
   });
 
   it('should not move when no transition', () => {
     const machine = createMooreStateMachine({
-      initialState: 'A',
+      initialNode: 'A',
       nodes,
     });
-    machine.handle('2');
-    expect(machine.getCurrentState().currentNode).toBe('A');
-    expect(machine.getCurrentState().output).toBe('OutputA');
-  });
-
-  it('should not move when state not defined', () => {
-    const machine = createMooreStateMachine({
-      initialState: 'C',
-      nodes,
-    });
-    machine.handle('1');
-    expect(machine.getCurrentState().currentNode).toBe('C');
-    expect(machine.getCurrentState().output).toBeUndefined();
+    machine.dispatch('2');
+    expect(machine.currentState.currentNode.id).toBe('A');
+    expect(machine.currentState.output).toBe('OutputA');
   });
 });

--- a/src/__tests__/state-machine/generic-state-machine.test.ts
+++ b/src/__tests__/state-machine/generic-state-machine.test.ts
@@ -1,122 +1,59 @@
 import { GenericStateMachine } from '../../lib';
 
 describe('deterministic-state-machine', () => {
-  it('should start at inital state', () => {
+  it('should start at initial state', () => {
     const machine = new GenericStateMachine(
-      'A',
-      new Set(['A']),
-      (_state, _event) => _state.currentNode,
+      { currentNode: { id: 'A' } },
+      [{ id: 'A' }],
+      (_state, _event) => _state.currentNode.id,
       (_state, _event) => 1,
     );
 
-    expect(machine.getCurrentState().currentNode).toBe('A');
-    expect(machine.getCurrentState().output).toBeUndefined();
+    expect(machine.currentState.currentNode.id).toBe('A');
+    expect(machine.currentState.output).toBeUndefined();
   });
 
   it('should stay at inital state', () => {
     const machine = new GenericStateMachine(
-      'A',
-      new Set(['A']),
-      (_state, _event) => _state.currentNode,
+      { currentNode: { id: 'A' } },
+      [{ id: 'A' }],
+      (_state, _event) => _state.currentNode.id,
       (_state, _event) => 1,
     );
 
-    const transition = machine.handle('X');
-    expect(transition.currentNode).toBe('A');
+    const transition = machine.dispatch('X');
+    expect(transition.currentNode.id).toBe('A');
     expect(transition.output).toBe(1);
-    expect(machine.getCurrentState().currentNode).toBe('A');
-    expect(machine.getCurrentState().output).toBe(1);
+    expect(machine.currentState.currentNode.id).toBe('A');
+    expect(machine.currentState.output).toBe(1);
   });
 
   it('should update current state when transitioning', () => {
     const machine = new GenericStateMachine(
-      'A',
-      new Set(['A']),
+      { currentNode: { id: 'A' } },
+      [{ id: 'A' }, { id: 'B' }],
       (_state, _event) => 'B',
       (_state, _event) => 1,
     );
 
-    const transition = machine.handle('X');
-    expect(transition.currentNode).toBe('B');
+    const transition = machine.dispatch('X');
+    expect(transition.currentNode.id).toBe('B');
     expect(transition.output).toBe(1);
-    expect(machine.getCurrentState().currentNode).toBe('B');
-    expect(machine.getCurrentState().output).toBe(1);
+    expect(machine.currentState.currentNode.id).toBe('B');
+    expect(machine.currentState.output).toBe(1);
   });
 
-  describe('canClose', () => {
-    it('should be true when at final state', () => {
-      const machine = new GenericStateMachine(
-        'A',
-        new Set(['A']),
-        (_state, _event) => 'B',
-        (_state, _event) => 1,
-      );
-      expect(machine.canClose()).toBeTruthy();
-    });
+  it('should get final node', () => {
+    const machine = new GenericStateMachine(
+      { currentNode: { id: 'A' } },
+      [{ id: 'A' }, { id: 'B', final: true }],
+      (_state, _event) => 'B',
+      (_state, _event) => 1,
+    );
 
-    it('should not be false when not at final state', () => {
-      const machine = new GenericStateMachine(
-        'A',
-        new Set(['B']),
-        (_state, _event) => 'B',
-        (_state, _event) => 1,
-      );
-      expect(machine.canClose()).toBeFalsy();
-    });
-  });
-
-  describe('close & isClosed', () => {
-    it('should be false when not yet closed', () => {
-      const machine = new GenericStateMachine(
-        'A',
-        new Set(['A']),
-        (_state, _event) => 'B',
-        (_state, _event) => 1,
-      );
-      expect(machine.isClosed()).toBeFalsy();
-    });
-
-    it('should be true when closed', () => {
-      const machine = new GenericStateMachine(
-        'A',
-        new Set(['A']),
-        (_state, _event) => 'B',
-        (_state, _event) => 1,
-      );
-      machine.close();
-      expect(machine.isClosed()).toBeTruthy();
-    });
-
-    it('should throw an error if we close an already closed machine', () => {
-      const machine = new GenericStateMachine(
-        'A',
-        new Set(['A']),
-        (_state, _event) => 'B',
-        (_state, _event) => 1,
-      );
-      machine.close();
-      expect(() => machine.close()).toThrowError();
-    });
-
-    it('should throw an error if we close when not at final state', () => {
-      const machine = new GenericStateMachine(
-        'A',
-        new Set(['B']),
-        (_state, _event) => 'B',
-        (_state, _event) => 1,
-      );
-      expect(() => machine.close()).toThrowError();
-    });
-
-    it('should throw an error if we call handle on a closed machine', () => {
-      const machine = new GenericStateMachine(
-        'A',
-        new Set(['A']),
-        (_state, _event) => 'B',
-        (_state, _event) => 1,
-      );
-      machine.close();
-      expect(() => machine.handle('X')).toThrowError();
-    });
+    const transition = machine.dispatch('X');
+    expect(machine.currentState.currentNode.id).toBe('B');
+    expect(machine.currentState.currentNode.final).toBeTruthy();
+    expect(machine.currentState.output).toBe(1);
   });
 });

--- a/src/lib/deterministic-fsm/deterministic-output.fn.ts
+++ b/src/lib/deterministic-fsm/deterministic-output.fn.ts
@@ -1,6 +1,0 @@
-import { MachineEvent, MachineTransitionFn, MachineState, MachineNode, MachineOutputFn } from '../state-machine-api';
-import { DeterministicTransitions } from './deterministic-transition-map';
-
-export const createDeterministicOutput: () => MachineOutputFn<void> = () => (): void => {
-  return undefined;
-};

--- a/src/lib/deterministic-fsm/deterministic-state-machine.ts
+++ b/src/lib/deterministic-fsm/deterministic-state-machine.ts
@@ -1,16 +1,69 @@
 import { createDeterministicTransitions } from './deterministic-transition.fn';
 import { DeterministicTransitions } from './deterministic-transition-map';
-import { createDeterministicOutput } from './deterministic-output.fn';
-import { MachineNode } from '../state-machine-api';
+import { MachineEvent, MachineNode, MachineNodeId, MachineState } from '../state-machine-api';
 import { GenericStateMachine } from '../state-machine';
+import { noOpOutput } from '../state-machine/no-op-output.fn';
 
 /**
  * In a deterministic automaton, every state has exactly one transition for each possible input.
  * In a non-deterministic automaton, an input can lead to one, more than one, or no transition for a given state.
  * This machine has no output (void) and only has state.
  */
-export class DeterministicStateMachine extends GenericStateMachine<void> {
-  constructor(initialState: MachineNode, finalNodes: Set<MachineNode>, transitions: DeterministicTransitions) {
-    super(initialState, finalNodes, createDeterministicTransitions(transitions), createDeterministicOutput());
+class DeterministicStateMachine extends GenericStateMachine<void> {
+  constructor(initialState: MachineState<void>, nodes: MachineNode[], transitions: DeterministicTransitions) {
+    super(initialState, nodes, createDeterministicTransitions(transitions), noOpOutput);
   }
+}
+
+// Utility for easy-building
+export interface DeterministicMachineDefinition {
+  initialNode: MachineNodeId;
+  nodes: DeterministicNode[];
+}
+
+export interface DeterministicNode {
+  id: MachineNodeId;
+  transitions: Map<MachineEvent, MachineNodeId>;
+  final: boolean;
+}
+
+/**
+ * Utility function to create a Mealy FSMm.
+ * @param definition - The mealy machine definition (nodes, transitions and outputs)
+ * Usage:
+ * createDeterministicMachine({
+ *   initialState: 'A',
+ *   nodes: [
+ *     {
+ *       name: 'A',
+ *       transitions: new Map([['1', 'B'], ['0', 'A']]),
+ *       final: true
+ *     },
+ *     {
+ *       name: 'B',
+ *       transitions: new Map([['1', 'B'], ['0', 'A']]),
+ *       final: false
+ *     },
+ * ]
+ * });
+ *
+ */
+export function createDeterministicMachine(definition: DeterministicMachineDefinition): DeterministicStateMachine {
+  // TODO: Validate definition:
+  // All nodes have defined transitions
+  // InitialState is one of the nodes (!!currentNode)
+  // All Transitions point to existing nodes
+  // All nodes have transitions for every event type
+
+  function createTransitions(): DeterministicTransitions {
+    return new Map<MachineNodeId, Map<MachineEvent, MachineNodeId>>(
+      definition.nodes.map((node) => [node.id, node.transitions]),
+    );
+  }
+
+  const nodes = definition.nodes.map((node) => ({ id: node.id, final: node.final } as MachineNode));
+  const currentNode = nodes.find((n) => n.id === definition.initialNode)!;
+  const initialState: MachineState<void> = { currentNode };
+
+  return new DeterministicStateMachine(initialState, nodes, createTransitions());
 }

--- a/src/lib/deterministic-fsm/deterministic-transition-map.ts
+++ b/src/lib/deterministic-fsm/deterministic-transition-map.ts
@@ -1,3 +1,3 @@
-import { MachineEvent, MachineNode } from '../state-machine-api';
+import { MachineEvent, MachineNodeId } from '../state-machine-api';
 
-export type DeterministicTransitions = Map<MachineNode, Map<MachineEvent, MachineNode>>;
+export type DeterministicTransitions = Map<MachineNodeId, Map<MachineEvent, MachineNodeId>>;

--- a/src/lib/deterministic-fsm/deterministic-transition.fn.ts
+++ b/src/lib/deterministic-fsm/deterministic-transition.fn.ts
@@ -1,17 +1,9 @@
-import { MachineEvent, MachineTransitionFn, MachineState, MachineNode } from '../state-machine-api';
+import { MachineEvent, MachineTransitionFn, MachineState, MachineNodeId } from '../state-machine-api';
 import { DeterministicTransitions } from './deterministic-transition-map';
 
 export const createDeterministicTransitions: (transitions: DeterministicTransitions) => MachineTransitionFn<void> = (
   transitions: DeterministicTransitions,
-) => (currentState: MachineState<void>, $event: MachineEvent): MachineNode => {
-  if (!transitions.has(currentState.currentNode)) {
-    return currentState.currentNode;
-  }
-
-  const node = transitions.get(currentState.currentNode)!;
-  if (!node.has($event)) {
-    return currentState.currentNode;
-  }
-
-  return node.get($event)!;
+) => (currentState: MachineState<void>, $event: MachineEvent): MachineNodeId => {
+  const node = transitions.get(currentState.currentNode.id);
+  return node?.get($event);
 };

--- a/src/lib/mealy-fsm/mealy-output-map.ts
+++ b/src/lib/mealy-fsm/mealy-output-map.ts
@@ -1,0 +1,3 @@
+import { MachineEvent, MachineNodeId } from '../state-machine-api';
+
+export type MealyOutputMap<T> = Map<MachineNodeId, Map<MachineEvent, T>>;

--- a/src/lib/mealy-fsm/mealy-output.fn.ts
+++ b/src/lib/mealy-fsm/mealy-output.fn.ts
@@ -1,17 +1,9 @@
 import { MachineEvent, MachineOutputFn, MachineState } from '../state-machine-api';
-import { MealyTransitionMap } from './mealy-transition-map';
+import { MealyOutputMap } from './mealy-output-map';
 
-export const createMealyOutput: <T>(transitions: MealyTransitionMap<T>) => MachineOutputFn<T> = <T>(
-  transitions: MealyTransitionMap<T>,
-) => (currentState: MachineState<T>, $event: MachineEvent): T => {
-  if (!transitions.has(currentState.currentNode)) {
-    return Object.create(null);
-  }
-
-  const node = transitions.get(currentState.currentNode)!;
-  if (!node.has($event)) {
-    return Object.create(null);
-  }
-
-  return node.get($event)!.output!;
+export const createMealyOutput: <T>(outputMap: MealyOutputMap<T>) => MachineOutputFn<T> = <T>(
+  outputMap: MealyOutputMap<T>,
+) => (currentState: MachineState<T>, $event: MachineEvent): T | undefined => {
+  const node = outputMap.get(currentState.currentNode.id);
+  return node?.get($event);
 };

--- a/src/lib/mealy-fsm/mealy-state-machine.ts
+++ b/src/lib/mealy-fsm/mealy-state-machine.ts
@@ -1,15 +1,94 @@
 import { createMealyTransitions } from './mealy-transition.fn';
 import { MealyTransitionMap } from './mealy-transition-map';
 import { createMealyOutput } from './mealy-output.fn';
-import { MachineNode } from '../state-machine-api';
+import { MachineEvent, MachineNode, MachineNodeId, MachineState } from '../state-machine-api';
 import { GenericStateMachine } from '../state-machine';
+import { MealyOutputMap } from './mealy-output-map';
 
 /**
  * The FSM also uses input actions, i.e., output depends on input and state.
  * The use of a Mealy FSM leads often to a reduction of the number of states.
  */
-export class MealyStateMachine<T> extends GenericStateMachine<T> {
-  constructor(initialState: MachineNode, finalNodes: Set<MachineNode>, transitions: MealyTransitionMap<T>) {
-    super(initialState, finalNodes, createMealyTransitions(transitions), createMealyOutput<T>(transitions));
+class MealyStateMachine<T> extends GenericStateMachine<T> {
+  constructor(
+    initialState: MachineState<T>,
+    nodes: MachineNode[],
+    transitions: MealyTransitionMap,
+    outputs: MealyOutputMap<T>,
+  ) {
+    super(initialState, nodes, createMealyTransitions(transitions), createMealyOutput<T>(outputs));
   }
+}
+
+// Utility for easy-building
+export interface MealyMachineDefinition<T> {
+  initialNode: MachineNodeId;
+  nodes: MealyNode<T>[];
+}
+
+export interface MealyNode<T> {
+  id: MachineNodeId;
+  transitions: Map<MachineEvent, MealyTransition<T>>;
+  final: boolean;
+}
+
+export interface MealyTransition<T> {
+  node: MachineNodeId;
+  output: T;
+}
+
+/**
+ * Utility function to create a Mealy FSMm.
+ * @param definition - The mealy machine definition (nodes, transitions and outputs)
+ * Usage:
+ * createMealyStateMachine({
+ *   initialState: 'A',
+ *   nodes: [
+ *     {
+ *       name: 'A',
+ *       transitions: new Map([['1', { 'B', 'A-to-B' }], ['0', { 'A', 'A-to-A' }]]),
+ *       final: true
+ *     },
+ *     {
+ *       name: 'B',
+ *       transitions: new Map([['1', { 'B', 'B-to-B' }], ['0', { 'A', 'B-to-A' }]]),
+ *       final: false
+ *     },
+ * ]
+ * });
+ *
+ */
+export function createMealyStateMachine<T>(definition: MealyMachineDefinition<T>): MealyStateMachine<T> {
+  // TODO: Validate definition:
+  // All nodes have defined transitions
+  // InitialState is one of the nodes (!!currentNode)
+  // All Transitions point to existing nodes
+
+  function createNodeTransition(node: MealyNode<T>) {
+    return new Map<MachineEvent, MachineNodeId>(
+      Array.from(node.transitions).map(([key, transition]) => [key, transition.node]),
+    );
+  }
+
+  function createTransitions(): MealyTransitionMap {
+    return new Map<MachineNodeId, Map<MachineEvent, MachineNodeId>>(
+      definition.nodes.map((node) => [node.id, createNodeTransition(node)]),
+    );
+  }
+
+  function createNodeOutputs(node: MealyNode<T>) {
+    return new Map<MachineEvent, T>(Array.from(node.transitions).map(([key, transition]) => [key, transition.output]));
+  }
+
+  function createOutputs(): MealyOutputMap<T> {
+    return new Map<MachineNodeId, Map<MachineEvent, T>>(
+      definition.nodes.map((node) => [node.id, createNodeOutputs(node)]),
+    );
+  }
+
+  const nodes = definition.nodes.map((node) => ({ id: node.id, final: node.final } as MachineNode));
+  const currentNode = nodes.find((n) => n.id === definition.initialNode)!;
+  const initialState: MachineState<T> = { currentNode };
+
+  return new MealyStateMachine<T>(initialState, nodes, createTransitions(), createOutputs());
 }

--- a/src/lib/mealy-fsm/mealy-transition-map.ts
+++ b/src/lib/mealy-fsm/mealy-transition-map.ts
@@ -1,7 +1,3 @@
-import { MachineNode, MachineEvent } from '../state-machine-api';
+import { MachineNodeId, MachineEvent } from '../state-machine-api';
 
-export class MealyTransition<T> {
-  constructor(public node: MachineNode, public output: T) {}
-}
-
-export type MealyTransitionMap<T> = Map<MachineNode, Map<MachineEvent, MealyTransition<T>>>;
+export type MealyTransitionMap = Map<MachineNodeId, Map<MachineEvent, MachineNodeId>>;

--- a/src/lib/mealy-fsm/mealy-transition.fn.ts
+++ b/src/lib/mealy-fsm/mealy-transition.fn.ts
@@ -1,17 +1,9 @@
-import { MachineEvent, MachineTransitionFn, MachineState, MachineNode } from '../state-machine-api';
+import { MachineEvent, MachineTransitionFn, MachineState, MachineNode, MachineNodeId } from '../state-machine-api';
 import { MealyTransitionMap } from './mealy-transition-map';
 
-export const createMealyTransitions: <T>(transitions: MealyTransitionMap<T>) => MachineTransitionFn<T> = <T>(
-  transitions: MealyTransitionMap<T>,
-) => (currentState: MachineState<T>, $event: MachineEvent): MachineNode => {
-  if (!transitions.has(currentState.currentNode)) {
-    return currentState.currentNode;
-  }
-
-  const node = transitions.get(currentState.currentNode)!;
-  if (!node.has($event)) {
-    return currentState.currentNode;
-  }
-
-  return node.get($event)!.node!;
+export const createMealyTransitions: <T>(transitions: MealyTransitionMap) => MachineTransitionFn<T> = <T>(
+  transitions: MealyTransitionMap,
+) => (currentState: MachineState<T>, $event: MachineEvent): MachineNodeId => {
+  const node = transitions.get(currentState.currentNode.id);
+  return node?.get($event);
 };

--- a/src/lib/moore-fsm/moore-output-map.ts
+++ b/src/lib/moore-fsm/moore-output-map.ts
@@ -1,3 +1,3 @@
-import { MachineNode } from '../state-machine-api';
+import { MachineNodeId } from '../state-machine-api';
 
-export type MooreOutputMap<T> = Map<MachineNode, T>;
+export type MooreOutputMap<T> = Map<MachineNodeId, T>;

--- a/src/lib/moore-fsm/moore-output.fn.ts
+++ b/src/lib/moore-fsm/moore-output.fn.ts
@@ -4,9 +4,5 @@ import { MooreOutputMap } from './moore-output-map';
 export const createMooreOutput: <T>(outputs: MooreOutputMap<T>) => MachineOutputFn<T> = <T>(
   outputs: MooreOutputMap<T>,
 ) => (currentState: MachineState<T>, $event: MachineEvent, nextNode: MachineNode): T | undefined => {
-  if (!outputs.has(nextNode)) {
-    return undefined;
-  }
-
-  return outputs.get(nextNode)!;
+  return outputs.get(nextNode.id);
 };

--- a/src/lib/moore-fsm/moore-transition-map.ts
+++ b/src/lib/moore-fsm/moore-transition-map.ts
@@ -1,3 +1,3 @@
-import { MachineNode, MachineEvent } from '../state-machine-api';
+import { MachineEvent, MachineNodeId } from '../state-machine-api';
 
-export type MooreTransitionMap = Map<MachineNode, Map<MachineEvent, MachineNode>>;
+export type MooreTransitionMap = Map<MachineNodeId, Map<MachineEvent, MachineNodeId>>;

--- a/src/lib/moore-fsm/moore-transition.fn.ts
+++ b/src/lib/moore-fsm/moore-transition.fn.ts
@@ -1,17 +1,9 @@
-import { MachineEvent, MachineTransitionFn, MachineState, MachineNode } from '../state-machine-api';
+import { MachineEvent, MachineTransitionFn, MachineState, MachineNodeId } from '../state-machine-api';
 import { MooreTransitionMap } from './moore-transition-map';
 
 export const createMooreTransitions: <T>(transitions: MooreTransitionMap) => MachineTransitionFn<T> = <T>(
   transitions: MooreTransitionMap,
-) => (currentState: MachineState<T>, $event: MachineEvent): MachineNode => {
-  if (!transitions.has(currentState.currentNode)) {
-    return currentState.currentNode;
-  }
-
-  const node = transitions.get(currentState.currentNode)!;
-  if (!node.has($event)) {
-    return currentState.currentNode;
-  }
-
-  return node.get($event)!;
+) => (currentState: MachineState<T>, $event: MachineEvent): MachineNodeId => {
+  const node = transitions.get(currentState.currentNode.id)!;
+  return node.get($event);
 };

--- a/src/lib/state-machine-api/machine-node.ts
+++ b/src/lib/state-machine-api/machine-node.ts
@@ -1,1 +1,6 @@
-export type MachineNode = string & {};
+export interface MachineNode {
+  id: string;
+  final?: boolean;
+}
+
+export type MachineNodeId = (string & {}) | undefined;

--- a/src/lib/state-machine-api/machine-output.fn.ts
+++ b/src/lib/state-machine-api/machine-output.fn.ts
@@ -1,4 +1,4 @@
-import { MachineEvent, MachineNode, MachineState } from '.';
+import { MachineEvent, MachineNode, MachineNodeId, MachineState } from '.';
 
 export type MachineOutputFn<TOutput> = (
   currentState: MachineState<TOutput>,

--- a/src/lib/state-machine-api/machine-state.ts
+++ b/src/lib/state-machine-api/machine-state.ts
@@ -1,5 +1,6 @@
-import { MachineNode } from './machine-node';
+import { MachineNode, MachineNodeId } from './machine-node';
 
-export class MachineState<TOutput> {
-  constructor(public currentNode: MachineNode, public output?: TOutput) {}
+export interface MachineState<T> {
+  currentNode: MachineNode;
+  output?: T;
 }

--- a/src/lib/state-machine-api/machine-transition.fn.ts
+++ b/src/lib/state-machine-api/machine-transition.fn.ts
@@ -1,3 +1,3 @@
-import { MachineEvent, MachineState, MachineNode } from '.';
+import { MachineEvent, MachineState, MachineNodeId } from '.';
 
-export type MachineTransitionFn<TOutput> = (currentState: MachineState<TOutput>, $event: MachineEvent) => MachineNode;
+export type MachineTransitionFn<TOutput> = (currentState: MachineState<TOutput>, $event: MachineEvent) => MachineNodeId;

--- a/src/lib/state-machine-api/state-machine.ts
+++ b/src/lib/state-machine-api/state-machine.ts
@@ -1,9 +1,6 @@
 import { MachineState } from './machine-state';
 import { MachineEvent } from './machine-event';
 export interface StateMachine<TOutput> {
-  getCurrentState(): MachineState<TOutput>;
-  handle($event: MachineEvent): MachineState<TOutput> | never;
-  canClose(): boolean;
-  isClosed(): boolean;
-  close(): MachineState<TOutput> | never;
+  currentState: MachineState<TOutput>;
+  dispatch($event: MachineEvent): void;
 }

--- a/src/lib/state-machine/no-op-output.fn.ts
+++ b/src/lib/state-machine/no-op-output.fn.ts
@@ -1,0 +1,3 @@
+import { MachineOutputFn } from '../state-machine-api';
+
+export const noOpOutput: MachineOutputFn<void> = (): void => undefined;


### PR DESCRIPTION
# Issue

Closes #46

# Description

Refactor close/canClose/isClosed into the node

## PR Type

What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [x] Yes
- [] No

## What is the new behavior?

API changes of current state & node definition.
Added definitions for all machines so machines API remains intact

# Changes Summary

- [x] Added "final" prop to node.
- [x] Refactored ctors of machines (privates)
